### PR TITLE
fix bug where node wouldn't start without bootstrap peers list

### DIFF
--- a/src/get-ipfs.ts
+++ b/src/get-ipfs.ts
@@ -39,8 +39,8 @@ const addBootstrapPeers = async (ipfs: ipfs, peers?: string[]) => {
       await ipfs.stop()
     }
     await Promise.all(peers.map(p => ipfs.bootstrap.add(p)))
-    await ipfs.start()
   }
+  await ipfs.start()
   return ipfs
 }
 


### PR DESCRIPTION
# Problem
ipfs node won't start unless you give a bootstrap list

# Solution
Move start logic outside of if statement so it starts regardless