### PR TITLE
add initial peers with swarm.connect instead of bootstrap list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ const ipfs = await getIpfs([config])
   // `permissions` are enabled if the browser is ipfs-capable (Opera or extension)
   // passed to `window.ipfs.enable` if available
   // prevents a permission dialog from appearing for every action
-  permissions: ['id', 'version', 'add', 'cat', 'dag'],
+  permissions: ['id', 'version', 'add', 'cat', 'dag', 'swarm'],
 
-  // `bootstrap` is a list of peers to be added to the node's bootstrap list
+  // `peers` is a list of peer multiaddrs to connect to on load
   // to work with the `js-ipfs` fallback, these must have available websocket ports
-  bootstrap: []
+  peers: []
+
+  // `browserPeers` is a list of peer multiaddrs to connect to only on fallback to an in-browser js-ipfs daemon
+  // note: these must be secure websocket or WebRTC addresses
+  browserPeers: []
+
+  // `localPeers` is a list of peer multiaddrs to connect to if using a local ipfs daemon (through ipfs companion for instance)
+  localPeers: []
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "get-ipfs",
-  "version": "0.0.0",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1168,27 +1168,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "@hapi/boom": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.3.tgz",
-      "integrity": "sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==",
-      "requires": {
-        "@hapi/hoek": "8.x.x"
-      }
-    },
-    "@hapi/content": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
-      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
-      "requires": {
-        "@hapi/boom": "7.x.x"
-      }
-    },
-    "@hapi/hoek": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
-      "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
-    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -1224,14 +1203,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.1",
         "fastq": "^1.6.0"
-      }
-    },
-    "@nodeutils/defaults-deep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
-      "integrity": "sha1-uxEk3I184LxdodZorOWBSSWO8gs=",
-      "requires": {
-        "lodash": "^4.15.0"
       }
     },
     "@octokit/endpoint": {
@@ -1863,19 +1834,6 @@
         "@types/node": "*"
       }
     },
-    "File": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
-      "integrity": "sha1-6Jn3dtJz4iQ7qGEFuzsFbQ+5VgQ=",
-      "requires": {
-        "mime": ">= 0.0.0"
-      }
-    },
-    "FileList": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/FileList/-/FileList-0.10.2.tgz",
-      "integrity": "sha1-YAOxqXFZNBZLZ8Q0rWqHQaHNFHo="
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -1891,47 +1849,6 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
-    },
-    "abstract-leveldown": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-      "requires": {
-        "xtend": "~4.0.0"
-      }
-    },
-    "accept": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.4.tgz",
-      "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
-    "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      }
     },
     "acorn": {
       "version": "5.7.3",
@@ -1962,11 +1879,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
-    },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1999,34 +1911,11 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ammo": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
-      "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
       "requires": {
         "string-width": "^2.0.0"
       }
@@ -2040,12 +1929,14 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2079,20 +1970,6 @@
       "dev": true,
       "requires": {
         "default-require-extensions": "^1.0.0"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -2167,21 +2044,11 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
-    },
-    "asmcrypto.js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
-      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
     },
     "asn1": {
       "version": "0.2.4",
@@ -2190,16 +2057,6 @@
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
-      }
-    },
-    "asn1.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
-      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -2224,6 +2081,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       },
@@ -2231,14 +2089,16 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2269,11 +2129,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
-    },
-    "b64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.3.tgz",
-      "integrity": "sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -2554,15 +2409,11 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2619,34 +2470,6 @@
         }
       }
     },
-    "base-x": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
-      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "base32-encode": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
-      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA=="
-    },
-    "base32.js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-    },
-    "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2656,151 +2479,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bech32": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
-    },
     "before-after-hook": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-    },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
-    "binary-querystring": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/binary-querystring/-/binary-querystring-0.1.2.tgz",
-      "integrity": "sha512-mrot/6OS3YIUSWMyv/9uyMbCDYQWxl+fVDsrJFjPFGcVT0xDCdEg/gbN6eguaCr0UqsuXdtJ3DQ3i2z2alnulg=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
-    "bip32": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
-      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
-      "requires": {
-        "bs58check": "^2.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.0.0",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "bitcoin-ops": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-    },
-    "bitcoinjs-lib": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz",
-      "integrity": "sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==",
-      "requires": {
-        "bech32": "^1.1.2",
-        "bip32": "^1.0.4",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.4.0",
-        "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.1",
-        "tiny-secp256k1": "^1.0.0",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
-      }
-    },
-    "bl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
-    "blob": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
-    },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-        }
-      }
-    },
-    "borc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.1.tgz",
-      "integrity": "sha512-vPLLC2/gS0QN4O3cnPh+8jLshkMMD4qIfs+B1TPGPh30WrtcfItaO6j4k9alsqu/hIgKi8dVdmMvTcbq4tIF7A==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.8",
-        "iso-url": "~0.4.4",
-        "json-text-sequence": "~0.1.0"
-      }
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -2808,15 +2491,11 @@
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
     },
-    "bourne": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
-      "integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg=="
-    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
       "requires": {
         "ansi-align": "^2.0.0",
         "camelcase": "^4.0.0",
@@ -2831,6 +2510,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2865,11 +2545,6 @@
         }
       }
     },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-    },
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
@@ -2893,19 +2568,6 @@
         }
       }
     },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "browserslist": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
@@ -2926,24 +2588,6 @@
         "fast-json-stable-stringify": "2.x"
       }
     },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "bser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
@@ -2959,68 +2603,17 @@
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "buffer-indexof": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
-      "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
-    },
-    "buffer-split": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-split/-/buffer-split-1.0.0.tgz",
-      "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
-      "requires": {
-        "buffer-indexof": "~0.0.0"
-      }
-    },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "bufferjs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
-      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
       "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
       "dev": true
-    },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-    },
-    "byteman": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/byteman/-/byteman-1.3.5.tgz",
-      "integrity": "sha512-FzWDstifFRxtHX234b93AGa1b77dA6NUFpEXe+AoG1NydGN//XDZLMXxRNUoMf7SYYhVxfpwUEUgQOziearJvA=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3077,30 +2670,6 @@
       "integrity": "sha512-xGBpPqoBvn3unBW7oxgb8aJn42K0m9m1/wyjmazah10Fq7bROGG3kRAE6OIyr3U3PIJUqGuebhCEdMk9OKJG0A==",
       "dev": true
     },
-    "call": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/call/-/call-4.0.2.tgz",
-      "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -3127,11 +2696,6 @@
         "caller-callsite": "^2.0.0"
       }
     },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3141,7 +2705,8 @@
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -3172,7 +2737,8 @@
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
     },
     "cardinal": {
       "version": "2.1.1",
@@ -3190,61 +2756,11 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "catbox": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
-      "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
-    "catbox-memory": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
-      "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
-      "requires": {
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "escape-string-regexp": "^1.0.5",
@@ -3257,187 +2773,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
-    },
-    "chunky": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/chunky/-/chunky-0.0.0.tgz",
-      "integrity": "sha1-HnWAojwIOJfSrWYkWefv2EZfYIo="
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
-    },
-    "cid-tool": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.1.0.tgz",
-      "integrity": "sha512-lss0IzW2uiLm+W8St00N23+ySnCoFTD7qPZB1WqqOSvT5mzDG8Di9e5LmcaEkNfFXh7xAmlPZmJnvWxAjVPErg==",
-      "requires": {
-        "cids": "~0.5.3",
-        "explain-error": "^1.0.4",
-        "multibase": "~0.5.0",
-        "multihashes": "~0.4.14",
-        "yargs": "^12.0.2"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-        },
-        "lcid": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-          "requires": {
-            "invert-kv": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
-        "os-locale": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-          "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
-    "cids": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.8.tgz",
-      "integrity": "sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.0",
-        "multihashes": "~0.4.14"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "multibase": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
-          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
-          "requires": {
-            "base-x": "3.0.4"
-          }
-        }
-      }
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "class-is": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3471,7 +2811,8 @@
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -3556,6 +2897,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
       "requires": {
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0",
@@ -3580,7 +2922,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3596,6 +2939,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3603,7 +2947,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.3.3",
@@ -3623,7 +2968,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "commitizen": {
       "version": "3.1.2",
@@ -3697,42 +3043,23 @@
         "dot-prop": "^3.0.0"
       }
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -3746,6 +3073,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
           }
@@ -3754,37 +3082,10 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
-        }
-      }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "content": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/content/-/content-3.0.7.tgz",
-      "integrity": "sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==",
-      "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         }
       }
     },
@@ -3913,21 +3214,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
-    },
-    "core-decorators": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
     },
     "core-js": {
       "version": "2.6.9",
@@ -3956,7 +3247,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -4006,33 +3298,9 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
       }
     },
     "cross-env": {
@@ -4049,6 +3317,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -4060,37 +3329,16 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
-      "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.8",
@@ -4153,11 +3401,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-queue": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/data-queue/-/data-queue-0.0.3.tgz",
-      "integrity": "sha512-6YOUFa/+lXklPO42RF4zIzzphG01Jp1eoWolzkQb6z5oVsSThLibZ63VmAze3KuIMTglFt551q8j0Zaswx5vGQ=="
-    },
     "data-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
@@ -4182,46 +3425,6 @@
         }
       }
     },
-    "datastore-core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.6.1.tgz",
-      "integrity": "sha512-bPMmMEHu96EaFS+OXeyjC0C1YnnQFiybvMszduYya7xlCpKiK24YgF/YZm1STj0IjI9zub9UkNw3eIBos2z9cw==",
-      "requires": {
-        "async": "^2.6.1",
-        "interface-datastore": "~0.6.0",
-        "pull-many": "^1.0.8",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "datastore-fs": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.7.0.tgz",
-      "integrity": "sha512-U8amTi/aWW391JYeFbIzjKtEqECXuMvDafD0XphsiaRKp0If4SwxgmlMn+y7BHlCRrf4/AYAwemVZBMBrSwIxA==",
-      "requires": {
-        "async": "^2.6.1",
-        "datastore-core": "~0.6.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.11",
-        "interface-datastore": "~0.6.0",
-        "mkdirp": "~0.5.1",
-        "pull-stream": "^3.6.9",
-        "write-file-atomic": "^2.3.0"
-      }
-    },
-    "datastore-level": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.10.0.tgz",
-      "integrity": "sha512-2ZkfI3xwtRK50N7DKCu4TmohUev0gs2KIR27QaE12Zo32wNJMIHY1OV5AES/VCdC1N8raAr/JIgPAInnPb1yLQ==",
-      "requires": {
-        "datastore-core": "~0.6.0",
-        "encoding-down": "^5.0.4",
-        "interface-datastore": "~0.6.0",
-        "level-js": "github:timkuijsten/level.js#idbunwrapper",
-        "leveldown": "^3.0.2",
-        "levelup": "^2.0.2",
-        "pull-stream": "^3.6.9"
-      }
-    },
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -4238,6 +3441,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -4245,7 +3449,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -4275,6 +3480,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -4294,7 +3500,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4333,24 +3540,6 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
       "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
       "dev": true
-    },
-    "deferred-leveldown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
-      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
-      "requires": {
-        "abstract-leveldown": "~4.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4422,16 +3611,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
-    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4450,29 +3629,11 @@
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
-    },
-    "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
     },
     "diff": {
       "version": "3.5.0",
@@ -4495,15 +3656,6 @@
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
-      }
-    },
-    "dns-packet": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
-      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
-      "requires": {
-        "ip": "^1.1.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "doctrine": {
@@ -4548,16 +3700,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4570,7 +3712,8 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -4594,128 +3737,19 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
-    "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
-      "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "encoding-down": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-      "requires": {
-        "abstract-leveldown": "^5.0.0",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "engine.io": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
-      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
-      "requires": {
-        "accepts": "~1.3.4",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~6.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
-      "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
       }
     },
     "env-ci": {
@@ -4728,41 +3762,11 @@
         "java-properties": "^1.0.0"
       }
     },
-    "epimetheus": {
-      "version": "1.0.92",
-      "resolved": "https://registry.npmjs.org/epimetheus/-/epimetheus-1.0.92.tgz",
-      "integrity": "sha512-rZqoUT63Xu3z5wPpTFPWkrIileJ9deOx/k/0ZPTiMSKBtPmJ9RzNrlo/M2UWvky7h8clrgc/s2uciq2mfruKrA==",
-      "requires": {
-        "prom-client": "^10.0.0"
-      },
-      "dependencies": {
-        "prom-client": {
-          "version": "10.2.3",
-          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
-          "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
-          "requires": {
-            "tdigest": "^0.1.1"
-          }
-        }
-      }
-    },
-    "err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "requires": {
-        "prr": "~1.0.1"
-      }
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -4810,7 +3814,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.12.0",
@@ -4864,190 +3869,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "ethereum-common": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-    },
-    "ethereumjs-account": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
-      "requires": {
-        "ethereumjs-util": "^5.0.0",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "ethereumjs-block": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.0.tgz",
-      "integrity": "sha512-Ye+uG/L2wrp364Zihdlr/GfC3ft+zG8PdHcRtsBFNNH1CkOhxOwdB8friBU85n89uRZ9eIMAywCq0F4CwT1wAw==",
-      "requires": {
-        "async": "^2.0.1",
-        "ethereumjs-common": "^1.1.0",
-        "ethereumjs-tx": "^1.2.2",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            }
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "merkle-patricia-tree": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-          "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-          "requires": {
-            "async": "^1.4.2",
-            "ethereumjs-util": "^5.0.0",
-            "level-ws": "0.0.0",
-            "levelup": "^1.2.1",
-            "memdown": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "rlp": "^2.0.0",
-            "semaphore": ">=1.0.1"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            }
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "ethereumjs-common": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz",
-      "integrity": "sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw=="
-    },
-    "ethereumjs-tx": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
-      }
-    },
-    "ethereumjs-util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-      "requires": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "ethjs-util": "^0.1.3",
-        "keccak": "^1.0.2",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "exec-sh": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
@@ -5061,6 +3882,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -5163,11 +3985,6 @@
         }
       }
     },
-    "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
-    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -5190,11 +4007,6 @@
         "jest-message-util": "^23.4.0",
         "jest-regex-util": "^23.3.0"
       }
-    },
-    "explain-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "extend": {
       "version": "3.0.2",
@@ -5317,11 +4129,6 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-    },
     "fast-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
@@ -5429,55 +4236,11 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "file-api": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/file-api/-/file-api-0.10.4.tgz",
-      "integrity": "sha1-LxASJttyfMAXKg3WiPL2iD1SiD0=",
-      "requires": {
-        "File": ">= 0.10.0",
-        "FileList": ">= 0.10.0",
-        "bufferjs": "> 0.2.0",
-        "file-error": ">= 0.10.0",
-        "filereader": ">= 0.10.3",
-        "formdata": ">= 0.10.0",
-        "mime": ">= 1.2.11",
-        "remedial": ">= 1.0.7"
-      }
-    },
-    "file-error": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/file-error/-/file-error-0.10.2.tgz",
-      "integrity": "sha1-ljtIuSc7PUuEtADuVxvHixc5cko="
-    },
-    "file-type": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
-      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
-    },
-    "filereader": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
-      "integrity": "sha1-x0fUos2PYeVBinwH/hJXpD8KzbE="
-    },
-    "filereader-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/filereader-stream/-/filereader-stream-2.0.0.tgz",
-      "integrity": "sha1-sw1aW/bRTGONfrVeGTq7mG+ASKE=",
-      "requires": {
-        "from2": "^2.1.0",
-        "typedarray-to-buffer": "^3.0.4"
-      }
     },
     "fileset": {
       "version": "2.0.3",
@@ -5488,11 +4251,6 @@
         "glob": "^7.0.3",
         "minimatch": "^3.0.3"
       }
-    },
-    "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5583,21 +4341,11 @@
         "resolve-dir": "^1.0.1"
       }
     },
-    "flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
-    },
     "fn-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
-    },
-    "fnv1a": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
-      "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU="
     },
     "for-in": {
       "version": "1.0.2",
@@ -5613,11 +4361,6 @@
       "requires": {
         "for-in": "^1.0.1"
       }
-    },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -5636,26 +4379,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formdata": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/formdata/-/formdata-0.10.4.tgz",
-      "integrity": "sha1-liH9wMw2H0oBEd5dJbNfanjcVaA=",
-      "requires": {
-        "File": "^0.10.2",
-        "FileList": "^0.10.2",
-        "bufferjs": "^2.0.0",
-        "filereader": "^0.10.3",
-        "foreachasync": "^3.0.0",
-        "remedial": "^1.0.7"
-      },
-      "dependencies": {
-        "bufferjs": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-2.0.0.tgz",
-          "integrity": "sha1-aF5x7VwGAOPXA/+b0BK7MnCjnig="
-        }
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5669,15 +4392,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -5693,7 +4412,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.9",
@@ -6243,42 +4963,11 @@
         }
       }
     },
-    "fsm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fsm/-/fsm-1.0.2.tgz",
-      "integrity": "sha1-4uubKXR+gGu7kPjVRT4vnXvSN4M=",
-      "requires": {
-        "split": "~0.3.0"
-      },
-      "dependencies": {
-        "split": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-          "requires": {
-            "through": "2"
-          }
-        }
-      }
-    },
-    "fsm-event": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fsm-event/-/fsm-event-2.1.0.tgz",
-      "integrity": "sha1-04VxbtOPnJL+qyumAeKqxsC6WpI=",
-      "requires": {
-        "fsm": "^1.0.2"
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "g-status": {
       "version": "2.0.2",
@@ -6291,558 +4980,11 @@
         "simple-git": "^1.85.0"
       }
     },
-    "gar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
-      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
-    "gc-stats": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
-      "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "optional": true
-        }
-      }
-    },
-    "get-browser-rtc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.0.2.tgz",
-      "integrity": "sha1-u81AyEUaftTvXDc7gWmkCd0dEdk="
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
-    "get-folder-size": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
-      "integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
-      "requires": {
-        "gar": "^1.0.4",
-        "tiny-each-async": "2.0.3"
-      }
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
@@ -6860,6 +5002,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -6936,15 +5079,11 @@
         }
       }
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7011,6 +5150,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
       "requires": {
         "ini": "^1.3.4"
       }
@@ -7088,7 +5228,8 @@
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -7121,70 +5262,6 @@
           "dev": true
         }
       }
-    },
-    "hapi": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.7.0.tgz",
-      "integrity": "sha512-UeMX1LMWmHEIgMlwZGK/3lhI7X0VRvOioVply0Y9qF+/O5woGdQzNB8ZmDnLOBjnB6bdWWHyo5DEamuCsE1vmg==",
-      "requires": {
-        "accept": "2.x.x",
-        "ammo": "2.x.x",
-        "boom": "5.x.x",
-        "call": "4.x.x",
-        "catbox": "7.x.x",
-        "catbox-memory": "2.x.x",
-        "cryptiles": "3.x.x",
-        "heavy": "4.x.x",
-        "hoek": "4.x.x",
-        "iron": "4.x.x",
-        "items": "2.x.x",
-        "joi": "11.x.x",
-        "mimos": "3.x.x",
-        "podium": "1.x.x",
-        "shot": "3.x.x",
-        "somever": "1.x.x",
-        "statehood": "5.x.x",
-        "subtext": "5.x.x",
-        "topo": "2.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "isemail": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-          "requires": {
-            "punycode": "2.x.x"
-          }
-        },
-        "joi": {
-          "version": "11.4.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-          "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "3.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
-    "hapi-set-header": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hapi-set-header/-/hapi-set-header-1.0.2.tgz",
-      "integrity": "sha1-KvrgAsZxnW1U8/qIRi+CKJLS3xM="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -7228,41 +5305,17 @@
         }
       }
     },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "requires": {
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -7296,95 +5349,11 @@
         }
       }
     },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
-    "heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
-    },
-    "heavy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.4.tgz",
-      "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
-    "hi-base32": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
-      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
-    },
     "highlight.js": {
       "version": "9.15.10",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
       "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
       "dev": true
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -7414,7 +5383,8 @@
     "hosted-git-info": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -7488,14 +5458,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "human-to-milliseconds": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/human-to-milliseconds/-/human-to-milliseconds-1.0.0.tgz",
-      "integrity": "sha512-Rp1uvdGYHZ8v6GCl3N6QW48MlABqvLCzKbeNPPddbFdDEC7G1G+8oq0hmCiem4PSJIDwLvAxkPi3FF5BDoeKew==",
-      "requires": {
-        "promisify-es6": "^1.0.3"
       }
     },
     "husky": {
@@ -7593,29 +5555,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "idb-readable-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
-      "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
       "dev": true
-    },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "import-fresh": {
       "version": "3.1.0",
@@ -7647,7 +5591,8 @@
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -7673,7 +5618,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
@@ -7681,54 +5627,11 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "inert": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/inert/-/inert-4.2.1.tgz",
-      "integrity": "sha512-qmbbZYPSzU/eOUOStPQvSjrU9IR1Q3uDtsEsVwnBQeZG43xu7Nrj6yuUrX3ice/03rv5dj/KiKB+NGCbiqH+aQ==",
-      "requires": {
-        "ammo": "2.x.x",
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x",
-        "lru-cache": "4.1.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7737,12 +5640,14 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inquirer": {
       "version": "6.2.0",
@@ -7763,27 +5668,6 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
-      }
-    },
-    "interface-connection": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.3.tgz",
-      "integrity": "sha512-OV9Rj7AhUlssWJTO6nOazJdPFGqWDOVZ3j5aM+i0RPKyTzR87vJ949VqhMyKkCIR0GBAaNqfB7F4YA70a/QWiw==",
-      "requires": {
-        "pull-defer": "~0.2.3"
-      }
-    },
-    "interface-datastore": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
-      "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
-      "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
-        "err-code": "^1.1.2",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "uuid": "^3.2.2"
       }
     },
     "interpret": {
@@ -7817,906 +5701,6 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "ip-address": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
-      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
-      "requires": {
-        "jsbn": "1.1.0",
-        "lodash": "^4.17.15",
-        "sprintf-js": "1.1.2"
-      },
-      "dependencies": {
-        "jsbn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        }
-      }
-    },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-    },
-    "ipfs": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.33.1.tgz",
-      "integrity": "sha512-He22aMi/qJYcao4zkh9fS1cZZWKPWIyO964j/Bt+DhEUVO79DBBGW+PuF3I8IfVE8ihDxImxNboal3pbZT9EdA==",
-      "requires": {
-        "@nodeutils/defaults-deep": "^1.1.0",
-        "async": "^2.6.1",
-        "big.js": "^5.2.2",
-        "binary-querystring": "~0.1.2",
-        "bl": "^2.1.2",
-        "boom": "^7.2.0",
-        "bs58": "^4.0.1",
-        "byteman": "^1.3.5",
-        "cid-tool": "~0.1.0",
-        "cids": "~0.5.5",
-        "debug": "^4.1.0",
-        "err-code": "^1.1.2",
-        "file-type": "^10.2.0",
-        "fnv1a": "^1.0.1",
-        "fsm-event": "^2.1.0",
-        "get-folder-size": "^2.0.0",
-        "glob": "^7.1.3",
-        "hapi": "^16.6.2",
-        "hapi-set-header": "^1.0.2",
-        "hoek": "^5.0.4",
-        "human-to-milliseconds": "^1.0.0",
-        "interface-datastore": "~0.6.0",
-        "ipfs-api": "^26.1.0",
-        "ipfs-bitswap": "~0.21.0",
-        "ipfs-block": "~0.8.0",
-        "ipfs-block-service": "~0.15.1",
-        "ipfs-http-response": "~0.2.0",
-        "ipfs-mfs": "~0.4.2",
-        "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.25.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipfs-unixfs-engine": "~0.33.0",
-        "ipld": "~0.19.1",
-        "ipld-bitcoin": "~0.1.8",
-        "ipld-dag-pb": "~0.14.11",
-        "ipld-ethereum": "^2.0.1",
-        "ipld-git": "~0.2.2",
-        "ipld-raw": "^2.0.1",
-        "ipld-zcash": "~0.1.6",
-        "ipns": "~0.3.0",
-        "is-ipfs": "~0.4.7",
-        "is-pull-stream": "~0.0.0",
-        "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "joi-multiaddr": "^2.0.0",
-        "libp2p": "~0.23.1",
-        "libp2p-bootstrap": "~0.9.3",
-        "libp2p-crypto": "~0.14.0",
-        "libp2p-kad-dht": "~0.10.6",
-        "libp2p-keychain": "~0.3.3",
-        "libp2p-mdns": "~0.12.0",
-        "libp2p-mplex": "~0.8.2",
-        "libp2p-record": "~0.6.0",
-        "libp2p-secio": "~0.10.0",
-        "libp2p-tcp": "~0.13.0",
-        "libp2p-webrtc-star": "~0.15.5",
-        "libp2p-websocket-star": "~0.9.0",
-        "libp2p-websockets": "~0.12.0",
-        "lodash": "^4.17.11",
-        "mafmt": "^6.0.2",
-        "mime-types": "^2.1.21",
-        "mkdirp": "~0.5.1",
-        "multiaddr": "^5.0.0",
-        "multiaddr-to-uri": "^4.0.0",
-        "multibase": "~0.5.0",
-        "multihashes": "~0.4.14",
-        "once": "^1.4.0",
-        "peer-book": "~0.8.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
-        "progress": "^2.0.1",
-        "prom-client": "^11.1.3",
-        "prometheus-gc-stats": "~0.6.0",
-        "promisify-es6": "^1.0.3",
-        "pull-abortable": "^4.1.1",
-        "pull-catch": "^1.0.0",
-        "pull-defer": "~0.2.3",
-        "pull-file": "^1.1.0",
-        "pull-ndjson": "~0.1.1",
-        "pull-paramap": "^1.2.2",
-        "pull-pushable": "^2.2.0",
-        "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-stream": "^1.3.4",
-        "pull-zip": "^2.0.1",
-        "pump": "^3.0.0",
-        "read-pkg-up": "^4.0.0",
-        "readable-stream": "3.0.6",
-        "receptacle": "^1.3.2",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^1.6.2",
-        "temp": "~0.8.3",
-        "update-notifier": "^2.5.0",
-        "yargs": "^12.0.2",
-        "yargs-promise": "^1.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-        },
-        "lcid": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-          "requires": {
-            "invert-kv": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "os-locale": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-          "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "read-pkg-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-          "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
-    "ipfs-api": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
-      "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
-      "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.2.2",
-        "bl": "^2.1.2",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.5",
-        "concat-stream": "^1.6.2",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-cbor": "~0.13.0",
-        "ipld-dag-pb": "~0.14.11",
-        "is-ipfs": "~0.4.7",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "libp2p-crypto": "~0.14.0",
-        "lodash": "^4.17.11",
-        "lru-cache": "^4.1.3",
-        "multiaddr": "^5.0.0",
-        "multibase": "~0.5.0",
-        "multihashes": "~0.4.14",
-        "ndjson": "^1.5.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-pushable": "^2.2.0",
-        "pull-stream-to-stream": "^1.3.4",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.0.6",
-        "stream-http": "^3.0.0",
-        "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "~0.1.1",
-        "tar-stream": "^1.6.2",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "ipfs-bitswap": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.2.tgz",
-      "integrity": "sha512-0e4aZlrCUTRfV2CxXjMpgSSVgVZhZD3iuEu1d7fDX9uLv7r0ZG2bN0/polE6yn+pl/whxmEPwQkGuA4e413eHA==",
-      "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.2.2",
-        "cids": "~0.5.5",
-        "debug": "^4.1.0",
-        "ipfs-block": "~0.8.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.find": "^4.6.0",
-        "lodash.groupby": "^4.6.0",
-        "lodash.isequalwith": "^4.4.0",
-        "lodash.isundefined": "^3.0.1",
-        "lodash.pullallwith": "^4.7.0",
-        "lodash.sortby": "^4.7.0",
-        "lodash.uniqwith": "^4.5.0",
-        "lodash.values": "^4.3.0",
-        "moving-average": "^1.0.0",
-        "multicodec": "~0.2.7",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-defer": "~0.2.3",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "varint-decoder": "~0.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multicodec": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.7.tgz",
-          "integrity": "sha512-96xc9zs7bsclMW0Po9ERnRFqcsWHY8OZ8JW/I8DeHG58YYJZy3cBGI00Ze7hz9Ix56DNHMTSxEj9cgoZByruMg==",
-          "requires": {
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "cids": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
-          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
-          "requires": {
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "~0.5.1",
-            "multihashes": "~0.4.14"
-          }
-        },
-        "multibase": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
-          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
-          "requires": {
-            "base-x": "3.0.4"
-          }
-        }
-      }
-    },
-    "ipfs-block-service": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.15.2.tgz",
-      "integrity": "sha512-iudmJO7UJZHonWoXyakuzy+bpV/7QVDm/g8eCqKN2BvhSjnLepaxdTyaXxJ76F2EOav1hdBP+U3Z9Mg/aCFPgg==",
-      "requires": {
-        "async": "^2.6.1"
-      }
-    },
-    "ipfs-http-response": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.2.2.tgz",
-      "integrity": "sha512-RMc9GUdyfFdOclobCXslfS+tGevJJs9ZhUv1xuJd32d1CVEd3PlZB2VBgWPMP5jXyZJWQ9kkAha8fBHGtC55Cw==",
-      "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.5.7",
-        "debug": "^4.1.1",
-        "file-type": "^8.0.0",
-        "filesize": "^3.6.1",
-        "get-stream": "^3.0.0",
-        "ipfs-unixfs": "~0.1.16",
-        "mime-types": "^2.1.21",
-        "multihashes": "~0.4.14",
-        "promisify-es6": "^1.0.3",
-        "stream-to-blob": "^1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "file-type": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "ipfs-mfs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.4.2.tgz",
-      "integrity": "sha512-6xcexwgnyXXbi3PeXfmCtKa8nMijm8lvRPvfm27/Jwv/gLU1sJkpI6KF0m/EBeM7mwl1pQYu4E03qVoz8hDxtA==",
-      "requires": {
-        "async": "^2.6.1",
-        "blob": "~0.0.4",
-        "cids": "~0.5.4",
-        "debug": "^4.0.1",
-        "file-api": "~0.10.4",
-        "filereader-stream": "^2.0.0",
-        "interface-datastore": "~0.6.0",
-        "ipfs-unixfs": "~0.1.15",
-        "ipfs-unixfs-engine": "~0.32.1",
-        "is-pull-stream": "~0.0.0",
-        "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "mortice": "^1.2.0",
-        "once": "^1.4.0",
-        "promisify-es6": "^1.0.3",
-        "pull-cat": "^1.1.11",
-        "pull-defer": "~0.2.2",
-        "pull-paramap": "^1.2.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-stream": "^1.3.4",
-        "pull-traverse": "^1.0.3",
-        "stream-to-pull-stream": "^1.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ipfs-unixfs-engine": {
-          "version": "0.32.8",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.32.8.tgz",
-          "integrity": "sha512-YqLppNmG5M0rFj7QOTdRjny8xNKxmqKJE5DCOtc2ZMaXd4Semq+rEH23N2Mr1jYpimboDnadcv6jszi5cWRexw==",
-          "requires": {
-            "async": "^2.6.1",
-            "cids": "~0.5.5",
-            "deep-extend": "~0.6.0",
-            "ipfs-unixfs": "~0.1.15",
-            "ipld-dag-pb": "~0.14.6",
-            "left-pad": "^1.3.0",
-            "multihashing-async": "~0.5.1",
-            "pull-batch": "^1.0.0",
-            "pull-block": "^1.4.0",
-            "pull-cat": "^1.1.11",
-            "pull-pair": "^1.1.0",
-            "pull-paramap": "^1.2.2",
-            "pull-pause": "0.0.2",
-            "pull-pushable": "^2.2.0",
-            "pull-stream": "^3.6.9",
-            "pull-through": "^1.0.18",
-            "pull-traverse": "^1.0.3",
-            "pull-write": "^1.1.4",
-            "rabin": "^1.6.0",
-            "sparse-array": "^1.3.1",
-            "stream-to-pull-stream": "^1.7.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "ipfs-multipart": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.1.tgz",
-      "integrity": "sha512-NAmCxgBkZ0usWXf8lMwYYEXvyzrqa65uy/1caVKm5yOKFoqXNrNOt4Ev99Pb+B0RMRqGSdfSvtnZM1cfhSSk2A==",
-      "requires": {
-        "@hapi/content": "^4.1.0",
-        "dicer": "~0.3.0"
-      }
-    },
-    "ipfs-repo": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.2.tgz",
-      "integrity": "sha512-TuhUdturwwG/hKdK2m1fv6Hz1hvHsdXQqAsDr0uEXK8WOfz7CZ9IHLU3feDTDhh8nr4fB0nOO5xaTz3cCZ+/9Q==",
-      "requires": {
-        "async": "^2.6.1",
-        "base32.js": "~0.1.0",
-        "big.js": "^5.2.2",
-        "cids": "~0.5.5",
-        "datastore-core": "~0.6.0",
-        "datastore-fs": "~0.7.0",
-        "datastore-level": "~0.10.0",
-        "debug": "^4.1.0",
-        "interface-datastore": "~0.6.0",
-        "ipfs-block": "~0.7.1",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "lodash.set": "^4.3.2",
-        "multiaddr": "^5.0.0",
-        "proper-lockfile": "^3.2.0",
-        "pull-stream": "^3.6.9",
-        "sort-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ipfs-block": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
-          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
-          "requires": {
-            "cids": "^0.5.3",
-            "class-is": "^1.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "ipfs-unixfs": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.16.tgz",
-      "integrity": "sha512-TX9Dyu77MxpLzGh/LcQne95TofOyvOeW0oOi72aBMMcV1ItP3684e6NTG9KY1qzdrC+ZUR8kT7y18J058n8KXg==",
-      "requires": {
-        "protons": "^1.0.1"
-      }
-    },
-    "ipfs-unixfs-engine": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.33.0.tgz",
-      "integrity": "sha512-NF4e9PB4I22Ca1qaGeCG0pBQOaYTpBWwgC+EKlAomwj6FD6BeFD4OpoaEAs9kp8dOdjY8yKrHe+tRg9AGgOoIw==",
-      "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.5.5",
-        "deep-extend": "~0.6.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-pb": "~0.14.11",
-        "left-pad": "^1.3.0",
-        "multihashing-async": "~0.5.1",
-        "pull-batch": "^1.0.0",
-        "pull-block": "^1.4.0",
-        "pull-cat": "^1.1.11",
-        "pull-pair": "^1.1.0",
-        "pull-paramap": "^1.2.2",
-        "pull-pause": "0.0.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "pull-through": "^1.0.18",
-        "pull-traverse": "^1.0.3",
-        "pull-write": "^1.1.4",
-        "rabin": "^1.6.0",
-        "sparse-array": "^1.3.1",
-        "stream-to-pull-stream": "^1.7.2"
-      }
-    },
-    "ipld": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.19.3.tgz",
-      "integrity": "sha512-MK7hKGT2bUFs82XjVgM+12RhrAALVAdS/2bXJX4zJR0hPSXe/jXIqv83DijLk98zEjMujoPxh/Er+VVXNSr4gw==",
-      "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.5.5",
-        "interface-datastore": "~0.6.0",
-        "ipfs-block": "~0.8.0",
-        "ipfs-block-service": "~0.15.0",
-        "ipfs-repo": "~0.25.0",
-        "ipld-dag-cbor": "~0.13.0",
-        "ipld-dag-pb": "~0.14.11",
-        "ipld-raw": "^2.0.1",
-        "merge-options": "^1.0.1",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-traverse": "^1.0.3"
-      }
-    },
-    "ipld-bitcoin": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.9.tgz",
-      "integrity": "sha512-50aih5PpUbu2gURijdYAZbldnmu5qrXu+VMWHVqCKmm9MUkOeBT67kzoLDWK95oWN+ahpfTaIMqPh2I3RreCCA==",
-      "requires": {
-        "async": "^2.6.1",
-        "bitcoinjs-lib": "^4.0.2",
-        "cids": "~0.5.6",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1"
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz",
-      "integrity": "sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==",
-      "requires": {
-        "borc": "^2.1.0",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.5",
-        "is-circular": "^1.0.2",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1",
-        "traverse": "~0.6.6"
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.11.tgz",
-      "integrity": "sha512-ja4FH6elDprVuJBkNObFlq7+9h1Q3aoQx5SSG/v3I9e7j19nwyuMhLJYwBhdv29LiqpyD2cEqNrJLm8lWn0lJg==",
-      "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.4",
-        "class-is": "^1.1.0",
-        "is-ipfs": "~0.4.2",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-traverse": "^1.0.3",
-        "stable": "~0.1.8"
-      }
-    },
-    "ipld-ethereum": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.3.tgz",
-      "integrity": "sha512-sJyKMMm8vPXC/cbOwV+f8emJ7FTmT12VYq70FfnNmPSfhtvYRdRtLPKG711KkqPOoTRC+nehQNII2Vwizw/6yg==",
-      "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
-        "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^2.1.0",
-        "ethereumjs-tx": "^1.3.3",
-        "ipfs-block": "~0.8.0",
-        "merkle-patricia-tree": "^3.0.0",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "rlp": "^2.0.0"
-      }
-    },
-    "ipld-git": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.3.tgz",
-      "integrity": "sha512-AbIlgbK0vgLqQ/U+kJmnLnK2+uxaMS6PdP/PBK5heBQII3Lb2IpYoMqdJja5wYISTYxGzJeh9PB2U/de3B0ucw==",
-      "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
-        "multicodec": "~0.4.0",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "smart-buffer": "^4.0.0",
-        "traverse": "~0.6.6"
-      },
-      "dependencies": {
-        "multicodec": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.4.0.tgz",
-          "integrity": "sha512-npzvuOHRJD172WiolvyF8mAS5JfWWJlVh22OcGZ4I5ZKyFVI4aFQYB5AcMtmMTWRsjiePlOHH/dnaZi8ZidWuA==",
-          "requires": {
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "ipld-raw": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-2.0.1.tgz",
-      "integrity": "sha512-wtP1I61YQoAPnRZqVeflrxjTi41+38ck2puEz9mnMlc0ChYRGc4ZSKcWDTk66EQuqEzDAdV71nOMKb3JzDfbsg==",
-      "requires": {
-        "cids": "~0.5.2",
-        "multihashing-async": "~0.5.1"
-      }
-    },
-    "ipld-zcash": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.6.tgz",
-      "integrity": "sha512-y/mFm0AJDODcQG4Limv9LxEuJJBkbmVVDx9jbRRbxJLn2czb+TMZ+lBVLFU37DITwgix7RuuPPWVcZCBFs2TTQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.5.2",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.5.1",
-        "zcash-bitcore-lib": "~0.13.20-rc3"
-      }
-    },
-    "ipns": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.3.0.tgz",
-      "integrity": "sha512-3X8xS4AVgRbsqaTfpJ4OzqAJ2DOYXl9lh7AV/gq7qyF14A+YXk1zmCKc6xXS2GJSVkvsnoRsVGPRrQnDQoNksw==",
-      "requires": {
-        "base32-encode": "^1.1.0",
-        "big.js": "^5.1.2",
-        "debug": "^3.1.0",
-        "interface-datastore": "~0.6.0",
-        "left-pad": "^1.3.0",
-        "libp2p-crypto": "~0.13.0",
-        "multihashes": "~0.4.14",
-        "nano-date": "^2.1.0",
-        "peer-id": "~0.11.0",
-        "protons": "^1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "iron": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.5.tgz",
-      "integrity": "sha1-TwQszri5c480a1mqc0yDqJvDFCg=",
-      "requires": {
-        "boom": "5.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -8740,7 +5724,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -8762,11 +5747,6 @@
       "requires": {
         "ci-info": "^2.0.0"
       }
-    },
-    "is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -8858,7 +5838,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -8875,55 +5856,14 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
-      "requires": {
-        "ip-regex": "^2.0.0"
-      }
-    },
-    "is-ipfs": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.8.tgz",
-      "integrity": "sha512-xIKUeA24IFMfkmeAPEOZL448X7a08c/KzAGQp1e/QxC9bx/NNEdT/ohob3SW6eJO2UwJNjsbfMeNZ2B+Dk2Fdg==",
-      "requires": {
-        "bs58": "4.0.1",
-        "cids": "~0.5.6",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "multibase": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
-          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
-          "requires": {
-            "base-x": "3.0.4"
-          }
-        }
       }
     },
     "is-module": {
@@ -8935,7 +5875,8 @@
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -8960,7 +5901,8 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-observable": {
       "version": "1.1.0",
@@ -8990,6 +5932,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
       "requires": {
         "path-is-inside": "^1.0.1"
       }
@@ -8997,7 +5940,8 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -9026,15 +5970,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-pull-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
-      "integrity": "sha1-o7w9HG0wVRUcRr3m85nv7SFEDKk="
-    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -9054,12 +5994,14 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -9088,7 +6030,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -9111,27 +6054,14 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "iso-random-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.0.tgz",
-      "integrity": "sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ=="
-    },
-    "iso-url": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
-      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -9282,11 +6212,6 @@
       "requires": {
         "handlebars": "^4.0.3"
       }
-    },
-    "items": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
     },
     "java-properties": {
       "version": "1.0.2",
@@ -10210,82 +7135,11 @@
         "merge-stream": "^1.0.1"
       }
     },
-    "joi": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
-      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "dependencies": {
-        "isemail": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-          "requires": {
-            "punycode": "2.x.x"
-          }
-        },
-        "topo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-          "requires": {
-            "hoek": "6.x.x"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "6.1.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-              "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-            }
-          }
-        }
-      }
-    },
-    "joi-browser": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-13.4.0.tgz",
-      "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
-    },
-    "joi-multiaddr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
-      "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
-      "requires": {
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
-      }
-    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -10358,7 +7212,8 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -10375,15 +7230,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -10418,31 +7266,6 @@
         "verror": "1.10.0"
       }
     },
-    "k-bucket": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
-      "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "randombytes": "^2.0.3"
-      }
-    },
-    "keccak": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-      "requires": {
-        "bindings": "^1.2.1",
-        "inherits": "^2.0.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "keypair": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
-      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
-    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -10464,19 +7287,11 @@
       "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
       "dev": true
     },
-    "latency-monitor": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
-      "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
-      "requires": {
-        "debug": "^2.6.0",
-        "lodash": "^4.17.4"
-      }
-    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
       "requires": {
         "package-json": "^4.0.0"
       }
@@ -10499,254 +7314,8 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
-    },
-    "length-prefixed-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.6.0.tgz",
-      "integrity": "sha512-gsJvrb5giDqil/ScQ7fEoplsI2Ch4DwnvnfTW2EGl9KBW6Ekzn8JSNESObqNAeZD8HkSjEMvc5XjhuB66fsSZQ==",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "level-codec": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5",
-        "xtend": "^4.0.0"
-      }
-    },
-    "level-js": {
-      "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-      "from": "github:timkuijsten/level.js#idbunwrapper",
-      "requires": {
-        "abstract-leveldown": "~2.4.1",
-        "idb-readable-stream": "0.0.4",
-        "ltgt": "^2.1.2",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
-      }
-    },
-    "level-mem": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-      "requires": {
-        "level-packager": "~4.0.0",
-        "memdown": "~3.0.0"
-      },
-      "dependencies": {
-        "memdown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-          "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
-          }
-        }
-      }
-    },
-    "level-packager": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-      "requires": {
-        "encoding-down": "~5.0.0",
-        "levelup": "^3.0.0"
-      },
-      "dependencies": {
-        "deferred-leveldown": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-          "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "inherits": "^2.0.3"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-          "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "xtend": "^4.0.0"
-          }
-        },
-        "levelup": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-          "requires": {
-            "deferred-leveldown": "~4.0.0",
-            "level-errors": "~2.0.0",
-            "level-iterator-stream": "~3.0.0",
-            "xtend": "~4.0.0"
-          }
-        }
-      }
-    },
-    "level-ws": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-      "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
-    "leveldown": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-      "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-      "requires": {
-        "abstract-leveldown": "~4.0.0",
-        "bindings": "~1.3.0",
-        "fast-future": "~1.0.2",
-        "nan": "~2.10.0",
-        "prebuild-install": "^4.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "bindings": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-          "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "levelup": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
-      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
-      "requires": {
-        "deferred-leveldown": "~3.0.0",
-        "level-errors": "~1.1.0",
-        "level-iterator-stream": "~2.0.0",
-        "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "level-errors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        }
-      }
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -10762,1261 +7331,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "libp2p": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.23.1.tgz",
-      "integrity": "sha512-ArCIJ+EHpeT2qdfEI1Q9sN8oIB0R3Lw7YKLbJKfhK7Mq/+kYug+6RJqgomLJDVDeChTWZa0oe7CB7wEt+IvEpA==",
-      "requires": {
-        "async": "^2.6.1",
-        "joi": "^13.4.0",
-        "joi-browser": "^13.4.0",
-        "libp2p-connection-manager": "~0.0.2",
-        "libp2p-floodsub": "~0.15.0",
-        "libp2p-ping": "~0.8.0",
-        "libp2p-switch": "~0.40.7",
-        "libp2p-websockets": "~0.12.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "peer-book": "~0.8.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-bootstrap": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.7.tgz",
-      "integrity": "sha512-GuuYoTh0UBBlph0WuuiewtDZqfYsXmhSdX+JLMzGY6uMuK5aLr7gCa++2zVyBoOIgn0yTq2F6n4vKaWoK9Hi0w==",
-      "requires": {
-        "async": "^2.6.1",
-        "debug": "^4.1.1",
-        "mafmt": "^6.0.4",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "peer-info": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-          "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-          "requires": {
-            "mafmt": "^6.0.2",
-            "multiaddr": "^6.0.3",
-            "peer-id": "~0.12.2",
-            "unique-by": "^1.0.0"
-          }
-        }
-      }
-    },
-    "libp2p-circuit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.2.2.tgz",
-      "integrity": "sha512-AG06iCD8RTT8yZQfR93NMHWXI3MpVKJw60UvVaejx8sQ5VUFvhknl2V7bhZqBOGsMlxiaAcIIgSBWm2PXaLVNA==",
-      "requires": {
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
-        "interface-connection": "^0.3.2",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "multistream-select": "^0.14.1",
-        "peer-id": "^0.11.0",
-        "peer-info": "~0.14.1",
-        "protons": "^1.0.1",
-        "pull-abortable": "^4.1.1",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-connection-manager": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.0.2.tgz",
-      "integrity": "sha512-G/OzMfxQe0lHx7ujibPqpFLCeMN9I5vNH0+Rs9zat6+uIT51Saupx95lyoyh5J8nh93ui2cNH7PQnwJMZVKa1A==",
-      "requires": {
-        "debug": "^3.1.0",
-        "latency-monitor": "^0.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-crypto": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
-      "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
-      "requires": {
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.2.2",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "~0.7.6",
-        "pem-jwk": "^1.5.1",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.9.9",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-      },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-crypto-secp256k1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.3.tgz",
-      "integrity": "sha512-DFrK89VdboacqM3vqWV8yt8FH9Ni181JJAOU2tRkJfUN9tNEV7VfZEg390NJxEQQbLsyH4HZ7on3QTpPHMHQZQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "multihashing-async": "~0.5.1",
-        "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "secp256k1": "^3.6.1"
-      }
-    },
-    "libp2p-floodsub": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.8.tgz",
-      "integrity": "sha512-tsRTRRz9vg3iPqhSgkn4gotX635Hp/VMxPd4VQZlRvO8pZsfZwd61Qn9Vx8bES881RhRX0YpGM4Sa0izInHEWA==",
-      "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "debug": "^4.1.1",
-        "length-prefixed-stream": "^1.6.0",
-        "libp2p-crypto": "~0.16.0",
-        "libp2p-pubsub": "~0.0.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "time-cache": "~0.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-          "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
-          "requires": {
-            "asmcrypto.js": "^2.3.2",
-            "asn1.js": "^5.0.1",
-            "async": "^2.6.1",
-            "bn.js": "^4.11.8",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.3.0",
-            "multihashing-async": "~0.5.1",
-            "node-forge": "~0.7.6",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.10"
-          }
-        },
-        "libp2p-crypto-secp256k1": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-          "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-          "requires": {
-            "async": "^2.6.2",
-            "bs58": "^4.0.1",
-            "multihashing-async": "~0.6.0",
-            "nodeify": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "secp256k1": "^3.6.2"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-              "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-              "requires": {
-                "blakejs": "^1.1.0",
-                "js-sha3": "~0.8.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "pem-jwk": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-          "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-          "requires": {
-            "asn1.js": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-identify": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.6.tgz",
-      "integrity": "sha512-QleYqI6f8ah6G6sQU9uaIa9FVOtyp6LtiqopfjrmAIO5Oz22Zw+dpT7FcEXvYP7kL036Es2vzZm0js0pOWw1MA==",
-      "requires": {
-        "multiaddr": "^6.0.4",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "peer-info": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-          "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-          "requires": {
-            "mafmt": "^6.0.2",
-            "multiaddr": "^6.0.3",
-            "peer-id": "~0.12.2",
-            "unique-by": "^1.0.0"
-          }
-        }
-      }
-    },
-    "libp2p-kad-dht": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.6.tgz",
-      "integrity": "sha512-s94YvwenmqppiC4HdKZiCGfii15zMvVy6hTQ0R+sRWzOazxXUemb59kDS3smsg1Q0IQMDDt5ZD70Y3vGX8onXQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "base32.js": "~0.1.0",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
-        "heap": "~0.2.6",
-        "interface-datastore": "~0.6.0",
-        "k-bucket": "^4.0.1",
-        "libp2p-crypto": "~0.13.0",
-        "libp2p-record": "~0.6.0",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "priorityqueue": "~0.2.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.8",
-        "varint": "^5.0.0",
-        "xor-distance": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.4.8",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-              "requires": {
-                "async": "^2.6.0",
-                "blakejs": "^1.1.0",
-                "js-sha3": "^0.7.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-keychain": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.3.6.tgz",
-      "integrity": "sha512-pwZoPCNyMIhKqMXgCgr87JIjW8H/0I0EtclzHKwQh/Ej5EbZMX/GjvrkBiYplgBvrWFtOl76GokTTvW0bOPB8Q==",
-      "requires": {
-        "async": "^2.6.1",
-        "interface-datastore": "~0.6.0",
-        "libp2p-crypto": "~0.16.0",
-        "merge-options": "^1.0.1",
-        "node-forge": "~0.7.6",
-        "pull-stream": "^3.6.8",
-        "sanitize-filename": "^1.6.1"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-          "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
-          "requires": {
-            "asmcrypto.js": "^2.3.2",
-            "asn1.js": "^5.0.1",
-            "async": "^2.6.1",
-            "bn.js": "^4.11.8",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.3.0",
-            "multihashing-async": "~0.5.1",
-            "node-forge": "~0.7.6",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.10"
-          }
-        },
-        "libp2p-crypto-secp256k1": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-          "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-          "requires": {
-            "async": "^2.6.2",
-            "bs58": "^4.0.1",
-            "multihashing-async": "~0.6.0",
-            "nodeify": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "secp256k1": "^3.6.2"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-              "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-              "requires": {
-                "blakejs": "^1.1.0",
-                "js-sha3": "~0.8.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "pem-jwk": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-          "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-          "requires": {
-            "asn1.js": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-mdns": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.3.tgz",
-      "integrity": "sha512-jJvmRc2hd8inWRpWBGwJnu4t4Qxg/5LCMwivwTp3Rqf/NRHdqAuArT5VroFdgIiay9pQ9LjrA2zXIpT2ZLDusA==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "libp2p-tcp": "~0.13.0",
-        "multiaddr": "^6.0.6",
-        "multicast-dns": "^7.2.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "peer-info": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-          "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-          "requires": {
-            "mafmt": "^6.0.2",
-            "multiaddr": "^6.0.3",
-            "peer-id": "~0.12.2",
-            "unique-by": "^1.0.0"
-          }
-        }
-      }
-    },
-    "libp2p-mplex": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.5.tgz",
-      "integrity": "sha512-L/1xbk8Mux2vroxfH2nfLrqyHfMdl4ScnIXhmQm19tlHZokcg/sadI5XmjdsBqMq3nP/q8wgNjIuX9IX6m1C6w==",
-      "requires": {
-        "async": "^2.6.2",
-        "chunky": "0.0.0",
-        "concat-stream": "^1.6.2",
-        "debug": "^4.1.0",
-        "interface-connection": "~0.3.3",
-        "pull-catch": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-stream": "^1.3.4",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "libp2p-ping": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.5.tgz",
-      "integrity": "sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==",
-      "requires": {
-        "libp2p-crypto": "~0.16.0",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-          "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
-          "requires": {
-            "asmcrypto.js": "^2.3.2",
-            "asn1.js": "^5.0.1",
-            "async": "^2.6.1",
-            "bn.js": "^4.11.8",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.3.0",
-            "multihashing-async": "~0.5.1",
-            "node-forge": "~0.7.6",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.10"
-          }
-        },
-        "libp2p-crypto-secp256k1": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-          "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-          "requires": {
-            "async": "^2.6.2",
-            "bs58": "^4.0.1",
-            "multihashing-async": "~0.6.0",
-            "nodeify": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "secp256k1": "^3.6.2"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-              "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-              "requires": {
-                "blakejs": "^1.1.0",
-                "js-sha3": "~0.8.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "pem-jwk": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-          "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-          "requires": {
-            "asn1.js": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-pubsub": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.0.4.tgz",
-      "integrity": "sha512-j6cup6pQ1060Qhn8Lw2wzoGISyvQgvsFNiGngn5Yld8LaHKgP2T6wgJMEe0e69uEa3yqCWxe+QWFO5RcA1AJDw==",
-      "requires": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "length-prefixed-stream": "^2.0.0",
-        "libp2p-crypto": "~0.16.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "time-cache": "~0.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "length-prefixed-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
-          "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-          "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
-          "requires": {
-            "asmcrypto.js": "^2.3.2",
-            "asn1.js": "^5.0.1",
-            "async": "^2.6.1",
-            "bn.js": "^4.11.8",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.3.0",
-            "multihashing-async": "~0.5.1",
-            "node-forge": "~0.7.6",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.10"
-          }
-        },
-        "libp2p-crypto-secp256k1": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-          "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-          "requires": {
-            "async": "^2.6.2",
-            "bs58": "^4.0.1",
-            "multihashing-async": "~0.6.0",
-            "nodeify": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "secp256k1": "^3.6.2"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-              "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-              "requires": {
-                "blakejs": "^1.1.0",
-                "js-sha3": "~0.8.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "pem-jwk": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-          "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-          "requires": {
-            "asn1.js": "^5.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-record": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.3.tgz",
-      "integrity": "sha512-FUJ69hb20SETlKmXkdlG7AJPPZmaRrzNBR2d4aTRVYcR2LPWzamGg6UeDEP5DAHXUqMhtEP38oEKcrLn07kaOw==",
-      "requires": {
-        "async": "^2.6.2",
-        "buffer-split": "^1.0.0",
-        "err-code": "^1.1.2",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.6.0",
-        "protons": "^1.0.1"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-          "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
-    "libp2p-secio": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.1.tgz",
-      "integrity": "sha512-zfryPonQ2GMhGBaF28/fHK2luLFgCfK2NBX1hJBcX7FaxQI7vfNo11Ks3Dm0LIzoKLpFBOOyZqeJ3ewJi/pgnw==",
-      "requires": {
-        "async": "^2.6.1",
-        "debug": "^4.1.0",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.14.0",
-        "multihashing-async": "~0.5.1",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
-        "protons": "^1.0.1",
-        "pull-defer": "~0.2.3",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-switch": {
-      "version": "0.40.8",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.8.tgz",
-      "integrity": "sha512-+xCO9qyFanPP93rg5ft/o+VvAUw6LanSpZVO+vMdaFP+EoLp7INzJTAKZC7FSF6HhuVqhpUd/Y8/fvPi6mZ4Yw==",
-      "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
-        "libp2p-circuit": "~0.2.1",
-        "libp2p-identify": "~0.7.2",
-        "lodash.includes": "^4.3.0",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^5.0.0",
-        "multistream-select": "~0.14.3",
-        "once": "^1.4.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.1.tgz",
-      "integrity": "sha512-gb9C6u+ax11+2ntXnaBPRveb/dyQ36j0dU6FLXcUSIO9ovkWWXduCZC0Fi/Uyc/CZAUYUsu/ACKSvEX+ELS9AQ==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "ip-address": "^6.1.0",
-        "lodash.includes": "^4.3.0",
-        "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.1.0",
-        "once": "^1.4.0",
-        "stream-to-pull-stream": "^1.7.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ip-address": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.1.0.tgz",
-          "integrity": "sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==",
-          "requires": {
-            "jsbn": "1.1.0",
-            "lodash": "^4.17.15",
-            "sprintf-js": "1.1.2"
-          }
-        },
-        "jsbn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        }
-      }
-    },
-    "libp2p-webrtc-star": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.8.tgz",
-      "integrity": "sha512-ONfDf0DCamO++xZRJsPA2SSlrutO+UxC80t56acShg6ViZItiY3Y1WaMO+87jVW2711x230NlmOVoQ/gHfJmVw==",
-      "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
-        "debug": "^4.1.0",
-        "epimetheus": "^1.0.92",
-        "hapi": "^16.6.2",
-        "inert": "^4.2.1",
-        "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.4",
-        "minimist": "^1.2.0",
-        "multiaddr": "^6.0.3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "simple-peer": "^9.1.2",
-        "socket.io": "^2.1.1",
-        "socket.io-client": "^2.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "webrtcsupport": "github:ipfs/webrtcsupport"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "peer-info": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-          "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-          "requires": {
-            "mafmt": "^6.0.2",
-            "multiaddr": "^6.0.3",
-            "peer-id": "~0.12.2",
-            "unique-by": "^1.0.0"
-          }
-        }
-      }
-    },
-    "libp2p-websocket-star": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.9.1.tgz",
-      "integrity": "sha512-OdQ31meWB5uisi69xNS+ePfrY+ebwNNnm2mgCynZhBvgUvglZscb5HpOQ4Syg4AwyUrZUlCPblW6jmIBPtUFBQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
-        "data-queue": "0.0.3",
-        "debug": "^4.1.0",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.14.1",
-        "mafmt": "^6.0.2",
-        "merge-recursive": "0.0.3",
-        "multiaddr": "^5.0.2",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.9",
-        "socket.io-client": "^2.1.1",
-        "socket.io-pull-stream": "~0.1.5",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "libp2p-websockets": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.3.tgz",
-      "integrity": "sha512-qA5YZv7RoxGUtMlcD8JwquonM0/19MCV0UPDRihCjzTi4wRgGKhIXZSwd/fs+8RRTKHMEUngAxit7ZLSlYgdQQ==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "multiaddr-to-uri": "^5.0.0",
-        "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multiaddr-to-uri": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.0.0.tgz",
-          "integrity": "sha512-aVc52fdGXso3DwvVKUTjMddhLyuFBXcpGSbsIju0lKiYKFBUEREXSLpcqTOZlO8w1G1TivVmDe4CBUKQ/xMm5A==",
-          "requires": {
-            "multiaddr": "^6.1.0"
-          }
-        }
       }
     },
     "lines-and-columns": {
@@ -12211,6 +7525,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -12231,7 +7546,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -12251,56 +7567,17 @@
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isequalwith": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-      "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
-    },
-    "lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -12320,30 +7597,23 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
-    "lodash.isundefined": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
-    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-    },
-    "lodash.pullallwith": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.pullallwith/-/lodash.pullallwith-4.7.0.tgz",
-      "integrity": "sha1-ZX5CAHENi1nWlO5SE2Yq4FEdEXA="
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
     },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -12364,11 +7634,6 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -12384,17 +7649,8 @@
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
-    },
-    "lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.7",
@@ -12440,11 +7696,6 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
-    "looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12467,50 +7718,24 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
       "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
       "dev": true
-    },
-    "mafmt": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.8.tgz",
-      "integrity": "sha512-6oRO2fwNiqXXiby8Anq9ULLQpcrZUsfR3Bs+Yn1DWd/Zd65xGS9fobKzzSsnM9nqUdUA3IggG0b1R3WamVsatA==",
-      "requires": {
-        "multiaddr": "^6.1.0"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        }
-      }
     },
     "magic-string": {
       "version": "0.25.3",
@@ -12564,6 +7789,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -12579,11 +7805,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
-    },
-    "map-or-similar": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -12642,16 +7863,6 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true
     },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -12659,37 +7870,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-      "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
-      }
-    },
-    "memoizerific": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-      "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
-      "requires": {
-        "map-or-similar": "^1.5.0"
       }
     },
     "meow": {
@@ -12715,19 +7895,6 @@
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
-    "merge-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
-      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
-      "requires": {
-        "is-plain-obj": "^1.1"
-      }
-    },
-    "merge-recursive": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/merge-recursive/-/merge-recursive-0.0.3.tgz",
-      "integrity": "sha1-3nkB78rsyQbYyrKtHpxHD1o9roQ="
-    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -12742,63 +7909,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
       "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
       "dev": true
-    },
-    "merkle-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
-    },
-    "merkle-patricia-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "ethereumjs-util": "^5.2.0",
-        "level-mem": "^3.0.1",
-        "level-ws": "^1.0.0",
-        "readable-stream": "^3.0.6",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
-      },
-      "dependencies": {
-        "level-ws": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-          "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.8",
-            "xtend": "^4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -12824,17 +7934,20 @@
     "mime": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -12848,38 +7961,14 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
-    "mimos": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
-      "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
-      "requires": {
-        "hoek": "4.x.x",
-        "mime-db": "1.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12887,7 +7976,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -12924,6 +8014,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -12931,7 +8022,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -12941,162 +8033,11 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "mortice": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.2.tgz",
-      "integrity": "sha512-zECpP0bCFVxlAbIJST7ZHQPm5ECKsJRaw4JfSmu5XQeSkO+UB8i+1GUxkskqLHHQfj/wGRWNDd8KBkWfHaZZkw==",
-      "requires": {
-        "observable-webworkers": "^1.0.0",
-        "p-queue": "^5.0.0",
-        "promise-timeout": "^1.3.0",
-        "shortid": "^2.2.8"
-      }
-    },
-    "moving-average": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/moving-average/-/moving-average-1.0.0.tgz",
-      "integrity": "sha512-97cgMz0U2zciiDp4xRl/n+MYgrm9l7UiYbtsBLPr0rhw6KH3m4LyK2w4d96V6+UwKo+ph7KtQSoL2qgnqZVgvA=="
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "multiaddr": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
-      "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
-      "requires": {
-        "bs58": "^4.0.1",
-        "class-is": "^1.1.0",
-        "ip": "^1.1.5",
-        "ip-address": "^5.8.9",
-        "lodash.filter": "^4.6.0",
-        "lodash.map": "^4.6.0",
-        "varint": "^5.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "multiaddr-to-uri": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
-      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
-      "requires": {
-        "multiaddr": "^6.0.3"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-          "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "hi-base32": "~0.5.0",
-            "ip": "^1.1.5",
-            "is-ip": "^2.0.0",
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
-    "multibase": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
-      "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
-      "requires": {
-        "base-x": "3.0.4"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        }
-      }
-    },
-    "multicast-dns": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
-      "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
-      "requires": {
-        "dns-packet": "^4.0.0",
-        "thunky": "^1.0.2"
-      }
-    },
-    "multicodec": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.5.tgz",
-      "integrity": "sha512-1kOifvwAqp9IdiiTKmpK2tS+LY6GHZdKpk3S2EvW4T32vlwDyA3hJoZtGauzqdedUPVNGChnTksEotVOCVlC+Q==",
-      "requires": {
-        "varint": "^5.0.0"
-      }
-    },
-    "multihashes": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
-      "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
-      "requires": {
-        "bs58": "^4.0.1",
-        "varint": "^5.0.0"
-      }
-    },
-    "multihashing-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
-      }
-    },
-    "multistream-select": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.6.tgz",
-      "integrity": "sha512-oRxaStv2thLDZi3eojRgolS9DHbH5WENV2NwN6VwubEwsuwSEALbmSyxQ7PSzB7rSjgX2LGpuMzZ9O+ZptbEyA==",
-      "requires": {
-        "async": "^2.6.3",
-        "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "interface-connection": "~0.3.3",
-        "once": "^1.4.0",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.3",
-        "pull-stream": "^3.6.13",
-        "semver": "^6.2.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "murmurhash3js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
-      "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -13107,29 +8048,9 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
-    "nano-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nano-date/-/nano-date-2.1.0.tgz",
-      "integrity": "sha1-veghPYoPKtGjoW6PRV7uJHX/2/k=",
-      "requires": {
-        "bignumber.js": "^4.0.4",
-        "core-decorators": "^0.20.0",
-        "memoizerific": "^1.11.2"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-        }
-      }
-    },
-    "nanoid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
-      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13162,22 +8083,6 @@
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
       "dev": true
     },
-    "ndjson": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
-      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^2.1.0",
-        "through2": "^2.0.3"
-      }
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -13193,38 +8098,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "nigel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
-      "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
-      "requires": {
-        "hoek": "4.x.x",
-        "vise": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
-    "node-abi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz",
-      "integrity": "sha512-kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==",
-      "requires": {
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -13240,11 +8115,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
-    },
-    "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -13296,31 +8166,11 @@
         }
       }
     },
-    "nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
-      "requires": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      },
-      "dependencies": {
-        "is-promise": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
-        }
-      }
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -13331,7 +8181,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -16842,6 +11693,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -16857,21 +11709,11 @@
         "which": "^1.2.10"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.1.4",
@@ -16888,12 +11730,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -16982,11 +11820,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "observable-webworkers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
-      "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ=="
-    },
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
@@ -16997,6 +11830,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -17028,12 +11862,6 @@
         }
       }
     },
-    "optional": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
-      "optional": true
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -17056,15 +11884,11 @@
         }
       }
     },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
@@ -17124,7 +11948,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -17135,7 +11960,8 @@
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
     },
     "p-filter": {
       "version": "2.1.0",
@@ -17157,12 +11983,14 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -17187,14 +12015,6 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
-    },
-    "p-queue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
-      "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
-      "requires": {
-        "eventemitter3": "^3.1.0"
-      }
     },
     "p-reduce": {
       "version": "2.1.0",
@@ -17222,6 +12042,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
       "requires": {
         "got": "^6.7.1",
         "registry-auth-token": "^3.0.1",
@@ -17232,12 +12053,14 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         },
         "got": {
           "version": "6.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -17255,12 +12078,14 @@
         "prepend-http": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
         },
         "registry-auth-token": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+          "dev": true,
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -17269,12 +12094,14 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -17329,6 +12156,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -17346,22 +12174,6 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -17371,284 +12183,40 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
-      }
-    },
-    "peer-book": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.8.0.tgz",
-      "integrity": "sha512-0An5viX2NnYeaqmwe2Vpzl03K9yxJ08mrktzkCPJyyd6rO4xz6QV2JK2Ku2vTHATP8Ag0ambxvr0QbrkT4UCYA==",
-      "requires": {
-        "bs58": "^4.0.1",
-        "peer-id": "^0.10.7",
-        "peer-info": "^0.14.1"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "peer-id": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.4.tgz",
-      "integrity": "sha512-AIAwL/6CmVc/VKbUhpA1rY3A/VJ3Z9ELvtvDQfl5cIi0A74L7lvsJ6LxQn5JSJVHM5Us2Ng9zMO523dO3FFnnw==",
-      "requires": {
-        "async": "^2.6.3",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-          "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
-          "requires": {
-            "asmcrypto.js": "^2.3.2",
-            "asn1.js": "^5.0.1",
-            "async": "^2.6.1",
-            "bn.js": "^4.11.8",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.3.0",
-            "multihashing-async": "~0.5.1",
-            "node-forge": "~0.7.6",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.10"
-          }
-        },
-        "libp2p-crypto-secp256k1": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.1.tgz",
-          "integrity": "sha512-evrfK/CeUSd/lcELUdDruyPBvxDmLairth75S32OLl3H+++2m2fV24JEtxzdFS9JH3xEFw0h6JFO8DBa1bP9dA==",
-          "requires": {
-            "async": "^2.6.2",
-            "bs58": "^4.0.1",
-            "multihashing-async": "~0.6.0",
-            "nodeify": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "secp256k1": "^3.6.2"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-              "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
-              "requires": {
-                "blakejs": "^1.1.0",
-                "js-sha3": "~0.8.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "pem-jwk": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-          "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-          "requires": {
-            "asn1.js": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "peer-info": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
-      "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
-      "requires": {
-        "lodash.uniqby": "^4.7.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "peer-id": "~0.10.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
-          }
-        },
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
-      }
-    },
-    "pem-jwk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
-      "integrity": "sha1-eoY3/S9nqCflfAxC4cI8P9Us+wE=",
-      "requires": {
-        "asn1.js": "1.0.3"
-      },
-      "dependencies": {
-        "asn1.js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
-          "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
-          "requires": {
-            "bn.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "bn.js": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
-          "integrity": "sha1-DbTL+W+PI7dC9by50ap6mZSgXoM=",
-          "optional": true
-        }
       }
     },
     "performance-now": {
@@ -17656,33 +12224,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "pez": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.5.tgz",
-      "integrity": "sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=",
-      "requires": {
-        "b64": "3.x.x",
-        "boom": "5.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "nigel": "2.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
     },
     "picomatch": {
       "version": "2.0.7",
@@ -17693,7 +12234,8 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -17804,74 +12346,11 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
-    "podium": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
-      "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
-      "requires": {
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
-    },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -17907,11 +12386,6 @@
         "ansi-styles": "^3.2.0"
       }
     },
-    "priorityqueue": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/priorityqueue/-/priorityqueue-0.2.1.tgz",
-      "integrity": "sha512-Dr6ZkRFGZHoAri6iNp5KvspOrFPfhxJ5AExXqLy5ChgdwALd3nC+q5/QG+gmjmf9W63joDXc+Zp0h05Ug/RtYg=="
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -17921,56 +12395,14 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-    },
-    "prom-client": {
-      "version": "11.5.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
-      "optional": true,
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
-    },
-    "prometheus-gc-stats": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.2.tgz",
-      "integrity": "sha512-ABSVHkAuYrMLj1WHmlLfS0hu9Vc2ELKuecwiMWPNQom+ZNiAdcILTn5yGK7sZg2ttoWc2u++W5NjdJ3IjdYJZw==",
-      "optional": true,
-      "requires": {
-        "gc-stats": "^1.2.1",
-        "optional": "^0.1.3"
-      }
-    },
-    "promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
-      "requires": {
-        "is-promise": "~1"
-      },
-      "dependencies": {
-        "is-promise": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
-        }
-      }
-    },
-    "promise-timeout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
-      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
-    },
-    "promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "prompt": {
       "version": "1.0.0",
@@ -17996,47 +12428,17 @@
         "sisteransi": "^0.1.1"
       }
     },
-    "proper-lockfile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
-      "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "property-expr": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
       "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
       "dev": true
     },
-    "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
-    },
-    "protons": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
-      "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
-      "requires": {
-        "protocol-buffers-schema": "^3.3.1",
-        "safe-buffer": "^5.1.1",
-        "signed-varint": "^2.0.1",
-        "varint": "^5.0.0"
-      }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.3.0",
@@ -18044,222 +12446,11 @@
       "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
       "dev": true
     },
-    "pull-abortable": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
-      "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
-    },
-    "pull-batch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-batch/-/pull-batch-1.0.0.tgz",
-      "integrity": "sha1-OopwhNsOmDxcWb8OB0qkHnU/Alg=",
-      "requires": {
-        "pull-through": "^1.0.18"
-      }
-    },
-    "pull-block": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pull-block/-/pull-block-1.4.0.tgz",
-      "integrity": "sha512-nqrFveL9SWdpM9FDkgUVifhbH/dgtK65Pmwa/rrdvB9avE32uWXb1uiemxczfrkqZaG4XVc139KdqfyvPoraoA==",
-      "requires": {
-        "pull-through": "^1.0.18"
-      }
-    },
-    "pull-cat": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
-    },
-    "pull-catch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-catch/-/pull-catch-1.0.1.tgz",
-      "integrity": "sha512-wrKbmEYySNETxOYXDTCJ8L/rcAFMayOifne2a+X9C0wSm6ttIWHHXwMYQh6k8iDRvtMM8itYkBlP4leKBJTiKA=="
-    },
-    "pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "pull-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
-      "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
-      "requires": {
-        "pull-utf8-decoder": "^1.0.2"
-      }
-    },
-    "pull-handshake": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-      "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-pair": "~1.1.0",
-        "pull-pushable": "^2.0.0",
-        "pull-reader": "^1.2.3"
-      }
-    },
-    "pull-length-prefixed": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.3.tgz",
-      "integrity": "sha512-tAvRbeHMrA3pqZVth8A0VAYeTG9+mpBpyzFPTwH65Jf6K5GYB3WFkvLSP/rgXFy+tJ+vqf6tol7gme13r0Z10g==",
-      "requires": {
-        "pull-pushable": "^2.2.0",
-        "pull-reader": "^1.3.1",
-        "safe-buffer": "^5.1.2",
-        "varint": "^5.0.0"
-      }
-    },
-    "pull-many": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.9.tgz",
-      "integrity": "sha512-+jUydDVlj/HsvtDqxWMSsiRq3B0HVo7RhBV4C0p2nZRS3mFTUEu9SPEBN+B5PMaW8KTnblYhTIaKg7oXgGnj4Q==",
-      "requires": {
-        "pull-stream": "^3.4.5"
-      }
-    },
-    "pull-ndjson": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-ndjson/-/pull-ndjson-0.1.1.tgz",
-      "integrity": "sha1-gx4GutmqbFxevBKol+Og4V1J4H4=",
-      "requires": {
-        "pull-split": "^0.2.0",
-        "pull-stream": "^3.4.5",
-        "pull-stringify": "^1.2.2"
-      }
-    },
-    "pull-pair": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-    },
-    "pull-paramap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
-      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
-      "requires": {
-        "looper": "^4.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        }
-      }
-    },
-    "pull-pause": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.2.tgz",
-      "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
-    },
-    "pull-pushable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-    },
-    "pull-reader": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
-      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
-    },
-    "pull-sort": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
-      "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
-      "requires": {
-        "pull-defer": "^0.2.3",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "pull-split": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.0.tgz",
-      "integrity": "sha1-mW0ohTEFIgmoMTiK0NKB3zyCN5Y=",
-      "requires": {
-        "pull-through": "~1.0.6"
-      }
-    },
-    "pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "pull-stream-to-stream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
-      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k="
-    },
-    "pull-stringify": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz",
-      "integrity": "sha1-Whw04Adfry8vbUYATjbczTO9fHw="
-    },
-    "pull-through": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-      "requires": {
-        "looper": "~3.0.0"
-      }
-    },
-    "pull-traverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
-    },
-    "pull-utf8-decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
-    },
-    "pull-write": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-      "requires": {
-        "looper": "^4.0.0",
-        "pull-cat": "^1.1.11",
-        "pull-stream": "^3.4.5"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        }
-      }
-    },
-    "pull-ws": {
-      "version": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225",
-      "from": "github:hugomrdias/pull-ws#fix/bundle-size",
-      "requires": {
-        "iso-url": "^0.4.4",
-        "relative-url": "^1.0.2",
-        "safe-buffer": "^5.1.1",
-        "ws": "^1.1.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        }
-      }
-    },
-    "pull-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pull-zip/-/pull-zip-2.0.1.tgz",
-      "integrity": "sha1-4GQc6v+WSvJ1ltqsBwDnmzgQKPU="
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -18268,15 +12459,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "pushdata-bitcoin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-      "requires": {
-        "bitcoin-ops": "^1.3.0"
-      }
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -18287,40 +12471,14 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
-    },
-    "rabin": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rabin/-/rabin-1.6.0.tgz",
-      "integrity": "sha1-4FaQsTBW8IyACY461xuQUwA441U=",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.2.1",
-        "bl": "^1.0.0",
-        "debug": "^2.2.0",
-        "minimist": "^1.2.0",
-        "nan": "^2.1.0",
-        "prebuild-install": "^2.1.0",
-        "readable-stream": "^2.0.4"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "optional": true,
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -18341,18 +12499,11 @@
         }
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -18373,6 +12524,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
@@ -18393,6 +12545,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -18410,21 +12563,6 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
-      }
-    },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "rechoir": {
@@ -18538,6 +12676,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
         "rc": "^1.0.1"
       }
@@ -18564,16 +12703,6 @@
           "dev": true
         }
       }
-    },
-    "relative-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
-    },
-    "remedial": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
-      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -18820,17 +12949,20 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -18911,7 +13043,8 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -18938,24 +13071,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
-    "rlp": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
-      "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
-      "requires": {
-        "bn.js": "^4.11.1",
-        "safe-buffer": "^5.1.1"
       }
     },
     "rollup": {
@@ -19164,40 +13279,6 @@
         "estree-walker": "^0.6.1"
       }
     },
-    "rsa-pem-to-jwk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
-      "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
-      "requires": {
-        "object-assign": "^2.0.0",
-        "rsa-unpack": "0.0.6"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-        }
-      }
-    },
-    "rsa-unpack": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
-      "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
-      "requires": {
-        "optimist": "~0.3.5"
-      },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        }
-      }
-    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -19237,7 +13318,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -19271,34 +13353,11 @@
         "watch": "~0.18.0"
       }
     },
-    "sanitize-filename": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz",
-      "integrity": "sha512-cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==",
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      }
     },
     "semantic-release": {
       "version": "15.13.21",
@@ -19633,11 +13692,6 @@
         }
       }
     },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
-    },
     "semver": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
@@ -19654,6 +13708,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
       "requires": {
         "semver": "^5.0.3"
       },
@@ -19661,7 +13716,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -19674,7 +13730,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -19699,19 +13756,11 @@
         }
       }
     },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -19719,7 +13768,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.3",
@@ -19738,45 +13788,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "shortid": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
-      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
-      "requires": {
-        "nanoid": "^2.0.0"
-      }
-    },
-    "shot": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
-      "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
-      "requires": {
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "signale": {
       "version": "1.4.0",
@@ -19800,29 +13816,6 @@
             "supports-color": "^5.3.0"
           }
         }
-      }
-    },
-    "signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
-      "requires": {
-        "varint": "~5.0.0"
-      }
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "simple-git": {
@@ -19851,43 +13844,6 @@
         }
       }
     },
-    "simple-peer": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.5.0.tgz",
-      "integrity": "sha512-3tROq3nBo/CIZI8PWlXGbAxQIlQF6KQ/zcd4lQ2pAC4+rPiV7E721hI22nTO54uw/nzb2HKbvmDtZ4Wr173+vA==",
-      "requires": {
-        "debug": "^4.0.1",
-        "get-browser-rtc": "^1.0.0",
-        "inherits": "^2.0.1",
-        "randombytes": "^2.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "sisteransi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -19905,11 +13861,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -20018,154 +13969,6 @@
         }
       }
     },
-    "socket.io": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
-      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
-      "requires": {
-        "debug": "~4.1.0",
-        "engine.io": "~3.3.1",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.2.0",
-        "socket.io-parser": "~3.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
-    },
-    "socket.io-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
-      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.3.1",
-        "has-binary2": "~1.0.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        }
-      }
-    },
-    "socket.io-pull-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/socket.io-pull-stream/-/socket.io-pull-stream-0.1.5.tgz",
-      "integrity": "sha512-lcC2se3iAS33xYGnTDSzYW9P4RPVEgcqACCH7Mawy+2go0Wmx3y72PXGv7KI6Vz1YFcOz7np58FqOnZ/iUCbdg==",
-      "requires": {
-        "data-queue": "0.0.3",
-        "debug": "^3.1.0",
-        "pull-stream": "^3.6.2",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "somever": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/somever/-/somever-1.0.1.tgz",
-      "integrity": "sha512-PCDMBcega4n7wuBUKmkiXidF3cOwtHHGg2qJYl0Rkw7StZqORoCgqce7HUuWNta/NAiQhwLDezNnTANxEWPCGA==",
-      "requires": {
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -20206,11 +14009,6 @@
       "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
       "dev": true
     },
-    "sparse-array": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
-      "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
-    },
     "spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -20221,6 +14019,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -20229,12 +14028,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -20243,7 +14044,8 @@
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "split": {
       "version": "1.0.1",
@@ -20267,6 +14069,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
       "requires": {
         "through2": "^2.0.2"
       }
@@ -20294,11 +14097,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -20316,53 +14114,6 @@
       "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
       "integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==",
       "dev": true
-    },
-    "statehood": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.4.tgz",
-      "integrity": "sha512-6/feFLqqHylvA/dHwJA0DgXvbEcKgbhRUeljsuu6+cIr8PO88nax7Wc+celZlPTncqT2arsxXL8P329Q1yfe9Q==",
-      "requires": {
-        "boom": "5.x.x",
-        "bourne": "1.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "iron": "4.x.x",
-        "items": "2.x.x",
-        "joi": "12.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        },
-        "isemail": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-          "requires": {
-            "punycode": "2.x.x"
-          }
-        },
-        "joi": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-          "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "3.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -20401,56 +14152,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "stream-http": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
-      "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "stream-to-blob": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.2.tgz",
-      "integrity": "sha512-ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==",
-      "requires": {
-        "once": "^1.3.3"
-      }
-    },
-    "stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-      "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
-      }
-    },
-    "streamifier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -20471,6 +14172,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -20480,6 +14182,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -20499,6 +14202,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -20506,20 +14210,14 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
@@ -20530,40 +14228,14 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "subtext": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.1.tgz",
-      "integrity": "sha512-zH/jaUKJ/bkrTpEe3zuTFIRnqAwv5xcGpXA2JaxEc30KRAT4k78jZnRqM45snjBSZAuvpI8chRUh1VZprcUVfw==",
-      "requires": {
-        "boom": "5.x.x",
-        "bourne": "1.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "pez": "2.x.x",
-        "wreck": "12.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -20604,81 +14276,11 @@
       "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
-      }
-    },
-    "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-      "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
       "requires": {
         "execa": "^0.7.0"
       },
@@ -20687,6 +14289,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -20697,6 +14300,7 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -20710,7 +14314,8 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         }
       }
     },
@@ -20921,51 +14526,24 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
     },
-    "thunky": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
-      "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow=="
-    },
-    "time-cache": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/time-cache/-/time-cache-0.3.0.tgz",
-      "integrity": "sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=",
-      "requires": {
-        "lodash.throttle": "^4.1.1"
-      }
-    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
-    "tiny-each-async": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
-      "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE="
-    },
-    "tiny-secp256k1": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.3.tgz",
-      "integrity": "sha512-ZpobrhOtHP98VYEN51IYQH1YcrbFpnxFhI6ceWa3OEbJn7eHvSd8YFjGPxbedGCy7PNYU1v/+BRsdvyr5uRd4g==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "bn.js": "^4.11.8",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.4.0",
-        "nan": "^2.13.2"
-      }
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -20981,16 +14559,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -21046,21 +14614,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "requires": {
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
-    },
     "toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -21097,7 +14650,8 @@
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "travis-deploy-once": {
       "version": "5.0.11",
@@ -21276,14 +14830,6 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
-    "truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
     "ts-jest": {
       "version": "23.10.5",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.5.tgz",
@@ -21449,6 +14995,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -21473,19 +15020,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "typedoc": {
       "version": "0.12.0",
@@ -21532,24 +15066,11 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
       "dev": true
     },
-    "typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-    },
     "typescript": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
-    },
-    "typestub-ipfs": {
-      "version": "0.23.14",
-      "resolved": "https://registry.npmjs.org/typestub-ipfs/-/typestub-ipfs-0.23.14.tgz",
-      "integrity": "sha512-bSP1UNslFux1xq+cg/tyNuTZnyhCgQZD1zM4WewIIDJ7tEmoNNkpOrvroKufK1hPOPWPmafy1QlFw86w7CY3bg==",
-      "requires": {
-        "ipfs": "^0.33.1"
-      }
     },
     "uglify-js": {
       "version": "3.6.0",
@@ -21570,11 +15091,6 @@
           "optional": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -21616,15 +15132,11 @@
         "set-value": "^2.0.1"
       }
     },
-    "unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
-    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
@@ -21687,12 +15199,14 @@
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
     },
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
       "requires": {
         "boxen": "^1.2.1",
         "chalk": "^2.0.1",
@@ -21709,12 +15223,14 @@
         "ci-info": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
           "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
           }
@@ -21757,30 +15273,17 @@
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
-    "ursa-optional": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
-      "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.11.1"
-      }
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -21817,36 +15320,17 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
-    },
-    "varint-decoder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
-      "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
-      "requires": {
-        "varint": "^5.0.0"
-      }
-    },
-    "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
       }
     },
     "verror": {
@@ -21858,21 +15342,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vise": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
-      "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
-      "requires": {
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
       }
     },
     "w3c-hr-time": {
@@ -21903,19 +15372,11 @@
         "minimist": "^1.2.0"
       }
     },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
-    },
-    "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
-      "from": "github:ipfs/webrtcsupport"
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -21947,6 +15408,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -21954,35 +15416,16 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
       "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
       "requires": {
         "string-width": "^2.1.1"
-      }
-    },
-    "wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "requires": {
-        "bs58check": "<3.0.0"
       }
     },
     "windows-release": {
@@ -22038,12 +15481,14 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -22052,12 +15497,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -22066,6 +15513,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -22076,6 +15524,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -22085,36 +15534,14 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "wreck": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
-      "integrity": "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-        }
-      }
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -22133,7 +15560,8 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -22141,30 +15569,23 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-    },
-    "xor-distance": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-1.0.0.tgz",
-      "integrity": "sha1-2nNdmyT8yo282bN00W0qAe6VQcY="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "11.1.0",
@@ -22206,16 +15627,6 @@
         "camelcase": "^4.1.0"
       }
     },
-    "yargs-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-promise/-/yargs-promise-1.1.0.tgz",
-      "integrity": "sha1-l+u1GY33NLs7EXRRM65bUBsWqx8="
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
@@ -22234,72 +15645,6 @@
         "property-expr": "^1.5.0",
         "synchronous-promise": "^2.0.6",
         "toposort": "^2.0.2"
-      }
-    },
-    "zcash-bitcore-lib": {
-      "version": "0.13.20-rc3",
-      "resolved": "https://registry.npmjs.org/zcash-bitcore-lib/-/zcash-bitcore-lib-0.13.20-rc3.tgz",
-      "integrity": "sha1-gToPVtz4t2vBQplRvqbRI2xQcAg=",
-      "requires": {
-        "bn.js": "=2.0.4",
-        "bs58": "=2.0.0",
-        "buffer-compare": "=1.0.0",
-        "elliptic": "=3.0.3",
-        "inherits": "=2.0.1",
-        "lodash": "=3.10.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
-          "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
-        },
-        "bs58": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
-          "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
-        },
-        "buffer-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
-          "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
-        },
-        "elliptic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
-          "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
-          "requires": {
-            "bn.js": "^2.0.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          },
-          "dependencies": {
-            "brorand": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
-              "integrity": "sha1-B7VMowKGq9Fxig4qgwgD79yb+gQ="
-            },
-            "hash.js": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-              "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-              "requires": {
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-ipfs",
-  "version": "0.0.5",
+  "version": "1.0.0-rc",
   "description": "Utility to get js-ipfs with fallbacks",
   "keywords": [],
   "main": "dist/get-ipfs.umd.js",


### PR DESCRIPTION
# Problem
- `isOnline` called while running ipfs companion was erroring
- adding peers by bootstrap list can be slow and clog up the bootstrap list

# Solution
- add initial peers with `swarm.connect` instead of stopping a node, changing bootstrap peers and restarting
- allow separate peers lists in config for browser vs local nodes