### PR TITLE
Renamed types file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.2
+Fix type exports bug
+
+## 1.1.1
+Add link to git repository in `package.json
+
 ## 1.1.0
 
 Allows you to define your own version of js-ipfs instead of the predefined fallback. Before it would load js-ipfs v0.38, now it loads the latest version from unpkg by default, which you can override as follows using this configuration property:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-ipfs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Utility to get js-ipfs with fallbacks",
   "keywords": [],
   "main": "dist/get-ipfs.umd.js",

--- a/src/get-ipfs.ts
+++ b/src/get-ipfs.ts
@@ -1,4 +1,4 @@
-import ipfs from './@types'
+import ipfs from './types'
 
 
 // Types

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,9 +3,7 @@
 
 import { EventEmitter } from 'events'
 
-export as namespace ipfs
-
-export = IPFS
+export default IPFS
 
 type Callback<T> = (error: Error, result?: T) => void
 


### PR DESCRIPTION
## Problem
`@types/index.d.ts` was a declaring file, so didn't get built into the package, which caused type errors when used.

## Solution
Rename to `types/index.ts` so now it gets built in as `types/index.d.ts`