### PR TITLE
include add, get, and cat in IPFS interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,13 @@
 # Changelog
 
+## 1.1.3
+Added `add`, `get`, and `cat` to IPFS interface
+
 ## 1.1.2
 Fix type exports bug
 
 ## 1.1.1
-Add link to git repository in `package.json
+Add link to git repository in `package.json`
 
 ## 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-ipfs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Utility to get js-ipfs with fallbacks",
   "keywords": [],
   "main": "dist/get-ipfs.umd.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,16 @@ declare class IPFS extends EventEmitter {
   on(event: string, callback: () => void): this
   on(event: 'error', callback: (error: { message: any }) => void): this
   once(event: string, callback: () => void): this
+
+  add(data: IPFS.FileContent, options: any, callback: Callback<IPFS.IPFSFile[]>): void
+  add(data: IPFS.FileContent, options?: any): Promise<IPFS.IPFSFile[]>
+  add(data: IPFS.FileContent, callback: Callback<IPFS.IPFSFile[]>): void
+
+  cat(hash: IPFS.Multihash, callback: Callback<IPFS.FileContent>): void
+  cat(hash: IPFS.Multihash): Promise<IPFS.FileContent>
+
+  get(hash: IPFS.Multihash, callback: Callback<IPFS.IPFSFile | IPFS.IPFSGetResult[]>): void
+  get(hash: IPFS.Multihash): Promise<IPFS.IPFSFile | IPFS.IPFSGetResult[]>
 }
 
 declare namespace IPFS {


### PR DESCRIPTION
## Problem
IPFS object has methods `add`, `get`, and `cat`. These aren't included in the IPFS interface type

## Solution
Add them to the interface