### PR TITLE
Made fn types AsyncIterable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+Made fn types `AsyncIterable` for `add`, `get`, and `cat`
+
 ## 1.1.3
 Added `add`, `get`, and `cat` to IPFS interface
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-ipfs",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Utility to get js-ipfs with fallbacks",
   "keywords": [],
   "main": "dist/get-ipfs.umd.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,15 +50,10 @@ declare class IPFS extends EventEmitter {
   on(event: 'error', callback: (error: { message: any }) => void): this
   once(event: string, callback: () => void): this
 
-  add(data: IPFS.FileContent, options: any, callback: Callback<IPFS.IPFSFile[]>): void
-  add(data: IPFS.FileContent, options?: any): Promise<IPFS.IPFSFile[]>
-  add(data: IPFS.FileContent, callback: Callback<IPFS.IPFSFile[]>): void
+  add(data: IPFS.FileContent, options?: any): AsyncIterable<IPFS.IPFSFile>
+  cat(hash: IPFS.Multihash): AsyncIterable<IPFS.FileContent>
 
-  cat(hash: IPFS.Multihash, callback: Callback<IPFS.FileContent>): void
-  cat(hash: IPFS.Multihash): Promise<IPFS.FileContent>
-
-  get(hash: IPFS.Multihash, callback: Callback<IPFS.IPFSFile | IPFS.IPFSGetResult[]>): void
-  get(hash: IPFS.Multihash): Promise<IPFS.IPFSFile | IPFS.IPFSGetResult[]>
+  get(hash: IPFS.Multihash): AsyncIterable<IPFS.IPFSFile | IPFS.IPFSGetResult>
 }
 
 declare namespace IPFS {
@@ -143,17 +138,9 @@ declare namespace IPFS {
 
     createPullStream(options: any): any
 
-    add(data: FileContent, options: any, callback: Callback<IPFSFile[]>): void
-    add(data: FileContent, options?: any): Promise<IPFSFile[]>
-    add(data: FileContent, callback: Callback<IPFSFile[]>): void
-
-    cat(hash: Multihash, callback: Callback<FileContent>): void
-    cat(hash: Multihash): Promise<FileContent>
-
-    get(hash: Multihash, callback: Callback<IPFSFile | IPFSGetResult[]>): void
-    get(hash: Multihash): Promise<IPFSFile | IPFSGetResult[]>
-
-    getPull(hash: Multihash, callback: Callback<any>): void
+    add(data: IPFS.FileContent, options?: any): AsyncIterable<IPFS.IPFSFile>
+    cat(hash: IPFS.Multihash): AsyncIterable<IPFS.FileContent>
+    get(hash: IPFS.Multihash): AsyncIterable<IPFS.IPFSFile | IPFS.IPFSGetResult>
   }
 
   export interface PeersOptions {


### PR DESCRIPTION
## Problem
After the latest ipfs update, the `add`/`get`/`cat` apis return `AsyncIterable`s

## Solution
Update the ipfs types to reflect this